### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/Pioneers-Ventures-Society-Main/src/admin/members/AddMemberForm.tsx
+++ b/Pioneers-Ventures-Society-Main/src/admin/members/AddMemberForm.tsx
@@ -40,6 +40,7 @@ export function AddMemberForm({ onMemberAdded, children }: AddMemberFormProps) {
   });
   const [formData, setFormData] = useState(initialFormData);
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
 
   const resetForm = () => {
     setFormData(initialFormData);
@@ -115,11 +116,28 @@ export function AddMemberForm({ onMemberAdded, children }: AddMemberFormProps) {
                     id="image-upload"
                     type="file"
                     accept="image/*"
-                    onChange={(e) => e.target.files && setImageFile(e.target.files[0])}
+                    onChange={(e) => {
+                      const file = e.target.files && e.target.files[0];
+                      if (file) {
+                        // Only allow safe image types (no SVG)
+                        const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+                        if (allowedTypes.includes(file.type)) {
+                          setImageFile(file);
+                          setImageError(null);
+                        } else {
+                          setImageFile(null);
+                          setImageError('Only JPG, PNG, GIF, or WebP images are allowed. SVG files are not supported for security reasons.');
+                        }
+                      } else {
+                        setImageFile(null);
+                        setImageError(null);
+                      }
+                    }}
                     className="flex-1"
                   />
                 </div>
                 {imageFile && <p className="text-sm text-muted-foreground mt-2">New image selected: {imageFile.name}</p>}
+                {imageError && <p className="text-sm text-destructive mt-2">{imageError}</p>}
               </div>
             </div>
             <div className="grid grid-cols-4 items-center gap-4"><Label htmlFor="spotlight" className="text-right">Feature on Homepage</Label><Switch id="spotlight" checked={formData.spotlight} onCheckedChange={(checked) => setFormData(prev => ({...prev, spotlight: checked}))} /></div>


### PR DESCRIPTION
Potential fix for [https://github.com/WyvernPirate/Pioneer-Ventures-Society/security/code-scanning/3](https://github.com/WyvernPirate/Pioneer-Ventures-Society/security/code-scanning/3)

To fix this issue, we need to prevent the possibility of loading SVG files (or any other potentially dangerous file types) as the `src` of the `<img>` tag. The best way to do this is to validate the file type before setting it as the preview image. We should only allow safe image types (e.g., JPEG, PNG, GIF, WebP) and explicitly reject SVG files. This can be done by checking the file's MIME type and/or extension in the `onChange` handler before calling `setImageFile`. If the file is not an allowed type, we should not set it as the preview image and optionally display an error message.

The changes should be made in the `onChange` handler for the file input (line 118) and in the state for error messages if needed. No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
